### PR TITLE
Revamp TDP control to support preset modes

### DIFF
--- a/backend/build.sh
+++ b/backend/build.sh
@@ -3,7 +3,7 @@
 #cargo build --release --target x86_64-unknown-linux-musl
 #cargo build --target x86_64-unknown-linux-musl
 #cross build
-cargo build
+cargo build --release
 
 mkdir -p ../bin
 #cp --preserve=mode ./target/x86_64-unknown-linux-musl/release/powertools ../bin/backend

--- a/backend/limits_core/src/json/base.rs
+++ b/backend/limits_core/src/json/base.rs
@@ -170,9 +170,11 @@ impl Default for Base {
                             clock_step: 100,
                         })),
                         super::Limits::Gpu(super::GpuLimit::GenericAMD(super::GenericGpuLimit {
-                            fast_ppt: Some(super::RangeLimit { min: Some(1_000), max: Some(30_000) }),
-                            slow_ppt: Some(super::RangeLimit { min: Some(1_000), max: Some(30_000) }),
+                            fast_ppt: Some(super::RangeLimit { min: Some(1_000), max: Some(53_000) }),
+                            slow_ppt: Some(super::RangeLimit { min: Some(1_000), max: Some(43_000) }),
                             ppt_step: Some(1_000),
+                            tdp: Some(super::RangeLimit { min: Some(1_000), max: Some(30_000) }),
+                            tdp_step: Some(1_000),
                             clock_min: Some(super::RangeLimit { min: Some(800), max: Some(2900) }),
                             clock_max: Some(super::RangeLimit { min: Some(800), max: Some(2900) }),
                             clock_step: Some(100),

--- a/backend/src/api/handler.rs
+++ b/backend/src/api/handler.rs
@@ -199,6 +199,12 @@ pub enum GpuMessage {
     GetClockLimits(Callback<Option<MinMax<u64>>>),
     SetSlowMemory(bool),
     GetSlowMemory(Callback<bool>),
+
+    // Set all 3: stapm, fast ppt, slow ppt
+    SetPptTdp(Option<u64>, Option<u64>, Option<u64>), // (tdp, fast, slow)
+    GetPptTdp(Callback<(Option<u64>, Option<u64>, Option<u64>)>),
+    GetPreset(Callback<Option<u64>>),
+    SetPreset(Option<u64>), // preset
 }
 
 impl GpuMessage {
@@ -211,6 +217,10 @@ impl GpuMessage {
             Self::GetClockLimits(cb) => cb(settings.get_clock_limits().map(|x| x.to_owned())),
             Self::SetSlowMemory(val) => *settings.slow_memory() = val,
             Self::GetSlowMemory(cb) => cb(*settings.slow_memory()),
+            Self::SetPptTdp(tdp,fast,slow) => settings.ppt_tdp(tdp, fast, slow),
+            Self::GetPptTdp(cb) => cb(settings.get_ppt_tdp()),
+            Self::GetPreset(cb) => cb(settings.get_preset()),
+            Self::SetPreset(val) => settings.set_preset(val),
         }
         dirty
     }
@@ -218,7 +228,7 @@ impl GpuMessage {
     fn is_modify(&self) -> bool {
         matches!(
             self,
-            Self::SetPpt(_, _) | Self::SetClockLimits(_) | Self::SetSlowMemory(_)
+            Self::SetPpt(_, _) | Self::SetClockLimits(_) | Self::SetSlowMemory(_) | Self::SetPptTdp(_, _, _) | Self::SetPreset(_)
         )
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -211,8 +211,12 @@ fn main() -> Result<(), ()> {
         )
         // gpu API functions
         .register("GPU_set_ppt", api::gpu::set_ppt(api_sender.clone()))
+        .register("GPU_set_preset", api::gpu::set_preset(api_sender.clone()))
         .register_async("GPU_get_ppt", api::gpu::get_ppt(api_sender.clone()))
+        .register_async("GPU_get_ppt_tdp", api::gpu::get_ppt_tdp(api_sender.clone()))
+        .register_async("GPU_get_preset", api::gpu::get_preset(api_sender.clone()))
         .register("GPU_unset_ppt", api::gpu::unset_ppt(api_sender.clone()))
+        .register("GPU_set_ppt_tdp", api::gpu::set_ppt_tdp(api_sender.clone()))
         .register(
             "GPU_set_clock_limits",
             api::gpu::set_clock_limits(api_sender.clone()),

--- a/backend/src/persist/gpu.rs
+++ b/backend/src/persist/gpu.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct GpuJson {
+    pub preset: Option<u64>,
+    pub stapm_ppt: Option<u64>,
     pub fast_ppt: Option<u64>,
     pub slow_ppt: Option<u64>,
     pub clock_limits: Option<MinMaxJson<u64>>,
@@ -17,6 +19,8 @@ pub struct GpuJson {
 impl Default for GpuJson {
     fn default() -> Self {
         Self {
+            preset: None,
+            stapm_ppt: None,
             fast_ppt: None,
             slow_ppt: None,
             clock_limits: None,

--- a/backend/src/resume_worker.rs
+++ b/backend/src/resume_worker.rs
@@ -27,7 +27,7 @@ pub fn spawn(sender: Sender<ApiMessage>) -> JoinHandle<()> {
                     old_start.as_secs_f32()
                 );
             } else {
-                log::debug!("OnResume got sleep period of {}s", old_start.as_secs_f32());
+                // log::debug!("OnResume got sleep period of {}s", old_start.as_secs_f32());
             }
             thread::sleep(duration);
         }

--- a/backend/src/settings/steam_deck/gpu.rs
+++ b/backend/src/settings/steam_deck/gpu.rs
@@ -345,6 +345,10 @@ impl Into<GpuJson> for Gpu {
     #[inline]
     fn into(self) -> GpuJson {
         GpuJson {
+            // TODO: Support Steam Deck
+            preset: None,
+            // TODO: Support Steam deck
+            stapm_ppt: None,
             fast_ppt: self.fast_ppt,
             slow_ppt: self.slow_ppt,
             clock_limits: self.clock_limits.map(|x| x.into()),
@@ -429,5 +433,21 @@ impl TGpu for Gpu {
 
     fn provider(&self) -> crate::persist::DriverJson {
         self.driver_mode.clone()
+    }
+
+    fn ppt_tdp(&mut self, _tdp: Option<u64>, _fast: Option<u64>, _slow: Option<u64>) {
+        todo!("Maybe support Steam Deck at some point?")
+    }
+
+    fn get_ppt_tdp(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
+        todo!("Not supported by Steam Deck!")
+    }
+
+    fn get_preset(&self) -> Option<u64> {
+        todo!()
+    }
+
+    fn set_preset(&mut self, _preset: Option<u64>) {
+        todo!()
     }
 }

--- a/backend/src/settings/traits.rs
+++ b/backend/src/settings/traits.rs
@@ -47,7 +47,11 @@ pub trait TGpu: OnSet + OnResume + OnPowerEvent + Debug + Send {
 
     fn ppt(&mut self, fast: Option<u64>, slow: Option<u64>);
 
+    fn ppt_tdp(&mut self, tdp: Option<u64>, fast: Option<u64>, slow: Option<u64>);
+
     fn get_ppt(&self) -> (Option<u64>, Option<u64>);
+
+    fn get_ppt_tdp(&self) -> (Option<u64>, Option<u64>, Option<u64>);
 
     fn clock_limits(&mut self, limits: Option<MinMax<u64>>);
 
@@ -58,6 +62,10 @@ pub trait TGpu: OnSet + OnResume + OnPowerEvent + Debug + Send {
     fn provider(&self) -> crate::persist::DriverJson {
         crate::persist::DriverJson::AutoDetect
     }
+
+    fn get_preset(&self) -> Option<u64>;
+
+    fn set_preset(&mut self, preset: Option<u64>);
 }
 
 pub trait TCpus: OnSet + OnResume + OnPowerEvent + Debug + Send {

--- a/backend/src/settings/unknown/gpu.rs
+++ b/backend/src/settings/unknown/gpu.rs
@@ -25,6 +25,8 @@ impl Into<GpuJson> for Gpu {
     #[inline]
     fn into(self) -> GpuJson {
         GpuJson {
+            preset: None,
+            stapm_ppt: None,
             fast_ppt: None,
             slow_ppt: None,
             clock_limits: None,
@@ -86,5 +88,19 @@ impl TGpu for Gpu {
 
     fn provider(&self) -> crate::persist::DriverJson {
         crate::persist::DriverJson::Unknown
+    }
+
+    fn ppt_tdp(&mut self, _tdp: Option<u64>, _fast: Option<u64>, _slow: Option<u64>) {}
+
+    fn get_ppt_tdp(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
+        (None, None, None)
+    }
+
+    fn get_preset(&self) -> Option<u64> {
+        todo!()
+    }
+
+    fn set_preset(&mut self, _preset: Option<u64>) {
+        todo!()
     }
 }

--- a/backend/src/state/generic/gpu.rs
+++ b/backend/src/state/generic/gpu.rs
@@ -3,6 +3,7 @@ pub struct Gpu {
     pub clock_limits_set: bool,
     pub old_fast_ppt: Option<u64>,
     pub old_slow_ppt: Option<u64>,
+    pub old_stapm_ppt: Option<u64>,
 }
 
 impl std::default::Default for Gpu {
@@ -11,6 +12,7 @@ impl std::default::Default for Gpu {
             clock_limits_set: false,
             old_fast_ppt: None,
             old_slow_ppt: None,
+            old_stapm_ppt: None,
         }
     }
 }

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -209,8 +209,24 @@ export async function setGpuPpt(fast: number, slow: number): Promise<number[]> {
     return (await call_backend("GPU_set_ppt", [fast, slow])); // -> [fastPPT, slowPPT]
 }
 
+export async function setGpuPptTdp(tdp: number, fast: number, slow: number): Promise<number[]> {
+    return (await call_backend("GPU_set_ppt_tdp", [tdp, fast, slow])); // -> [tdp, fastPPT, slowPPT]
+}
+
+export async function setPreset(profile: number): Promise<number> {
+    return (await call_backend("GPU_set_preset", [profile]));
+}
+
 export async function getGpuPpt(): Promise<number[]> {
     return (await call_backend("GPU_get_ppt", [])); // -> [fastPPT, slowPPT]
+}
+
+export async function getPreset(): Promise<number> {
+    return (await call_backend("GPU_get_preset", []));
+}
+
+export async function getGpuPptTdp(): Promise<number[]> {
+    return (await call_backend("GPU_get_ppt_tdp", [])); // -> [tdp, fastPPT, slowPPT]
 }
 
 export async function unsetGpuPpt(): Promise<any[]> {

--- a/src/components/gpu.tsx
+++ b/src/components/gpu.tsx
@@ -1,10 +1,13 @@
 import { Fragment } from "react";
-import {Component} from "react";
+import { Component } from "react";
 import {
-  ToggleField,
-  SliderField,
-  PanelSectionRow,
-  staticClasses,
+    ToggleField,
+    SliderField,
+    PanelSectionRow,
+    staticClasses,
+    Field,
+    Dropdown,
+    SingleDropdownOption,
 } from "decky-frontend-lib";
 import * as backend from "../backend";
 import { tr } from "usdpl-front";
@@ -13,8 +16,9 @@ import {
     SLOW_PPT_GPU,
     FAST_PPT_GPU,
     TDP,
+    PRESET_MODE_GPU,
 } from "../consts";
-import { set_value, get_value} from "usdpl-front";
+import { set_value, get_value } from "usdpl-front";
 
 export class Gpu extends Component<backend.IdcProps> {
     constructor(props: backend.IdcProps) {
@@ -25,66 +29,140 @@ export class Gpu extends Component<backend.IdcProps> {
     }
 
     render() {
-        const reloadGUI = (x: string) => this.setState({reloadThingy: x});
+        const reloadGUI = (x: string) => this.setState({ reloadThingy: x });
+
+        const performanceDropdown: SingleDropdownOption[] = [
+            {data: 0, label: <span>Silent 10W</span> }, 
+            {data: 1, label: <span>Peformance 15W</span> }, 
+            {data: 2, label: <span>Turbo 25W</span>}, 
+            {data: 3, label: <span>Turbo 30W</span>}, 
+            {data: 4, label: <span>Manual</span>}
+        ];
+
+        const labels : string [] = ["Silent 10W", "Performance 15W", "Turbo 25W", "Turbo 30W", "Manual"];
+
         return (<Fragment>
-                {/* GPU */}
+            {/* GPU */}
             <div className={staticClasses.PanelSectionTitle}>
                 {tr("GPU")}
             </div>
-            { ((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits != null ||(get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits != null) && <PanelSectionRow>
+            {((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits != null || (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits != null) && <PanelSectionRow>
                 <ToggleField
-                checked={get_value(SLOW_PPT_GPU) != null || get_value(FAST_PPT_GPU) != null}
-                label={tr("Thermal Power (TDP) Limit")}
-                description={tr("Limits processor power for less total power")}
-                onChange={(value: boolean) => {
-                    if (value) {
-                        if ((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits != null) {
-                            set_value(SLOW_PPT_GPU, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.max);
+                    checked={get_value(SLOW_PPT_GPU) != null || get_value(FAST_PPT_GPU) != null}
+                    label={tr("Thermal Power (TDP) Limit")}
+                    description={tr("Limits processor power for less total power")}
+                    onChange={(value: boolean) => {
+                        if (value) {
+                            if ((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits != null) {
+                                set_value(SLOW_PPT_GPU, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.max);
 
-                            // Set it to midpoint
-                            set_value(TDP, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.max/2000);
-                        }
+                                // Set it to midpoint
+                                set_value(TDP, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.max / 2000);
+                            }
 
-                        if ((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits != null) {
-                            set_value(FAST_PPT_GPU, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits!.max);
+                            if ((get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits != null) {
+                                set_value(FAST_PPT_GPU, (get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.fast_ppt_limits!.max);
+                            }
+                            reloadGUI("GPUPPTToggle");
+                        } else {
+                            set_value(SLOW_PPT_GPU, null);
+                            set_value(FAST_PPT_GPU, null);
+                            set_value(TDP, null);
+                            backend.resolve(backend.unsetGpuPpt(), (_: any[]) => {
+                                reloadGUI("GPUUnsetPPT");
+                            });
                         }
-                        reloadGUI("GPUPPTToggle");
-                    } else {
-                        set_value(SLOW_PPT_GPU, null);
-                        set_value(FAST_PPT_GPU, null);
-                        set_value(TDP, null);
-                        backend.resolve(backend.unsetGpuPpt(), (_: any[]) => {
-                            reloadGUI("GPUUnsetPPT");
-                        });
-                    }
-                }}
+                    }}
                 />
             </PanelSectionRow>}
             <PanelSectionRow>
-                {get_value(TDP) != null && <SliderField
+                    <Field
+                    label={tr("Performance Preset")}
+                    >
+                    <Dropdown
+                        menuLabel={tr("Performance")}
+                        rgOptions={performanceDropdown}
+                        selectedOption={performanceDropdown.find((val: SingleDropdownOption, _index, _arr) => {
+                            backend.log(backend.LogLevel.Info, "Checking selected option: " + val.data.toString());
+
+                            // Default to Performance 15W
+                            if (get_value(PRESET_MODE_GPU) == null) {
+                                backend.log(backend.LogLevel.Info, "Preset mode is null");
+                                return val.data == 1;
+                            } else {
+                                backend.log(backend.LogLevel.Info, "Preset mode is " + get_value(PRESET_MODE_GPU).toString());
+                            }
+                            return val.data == get_value(PRESET_MODE_GPU);
+                        })}
+                        strDefaultLabel={get_value(PRESET_MODE_GPU) == null ? "Performance 15W" : labels[get_value(PRESET_MODE_GPU)]}
+                        onChange={(elem: SingleDropdownOption) => {
+                            backend.log(backend.LogLevel.Debug, "Performance dropdown selected " + elem.data.toString());
+                            backend.resolve(backend.setPreset(elem.data), (value) => {
+                                backend.log(backend.LogLevel.Info, "Preset mode is now " + value.toString());
+                                set_value(PRESET_MODE_GPU, value);
+                            });
+                            switch (elem.data) {
+                                case 0:
+                                    backend.resolve(backend.setGpuPptTdp(10000, 17000, 14000), (limits: number[]) => {
+                                        set_value(TDP, limits[0]/1000);
+                                        set_value(FAST_PPT_GPU, limits[1]);
+                                        set_value(SLOW_PPT_GPU, limits[2]);
+                                    });
+                                    break;
+                                case 1:
+                                    backend.resolve(backend.setGpuPptTdp(15000, 25000, 20000), (limits: number[]) => {
+                                        set_value(TDP, limits[0]/1000);
+                                        set_value(FAST_PPT_GPU, limits[1]);
+                                        set_value(SLOW_PPT_GPU, limits[2]);
+                                    });
+                                    break;
+                                case 2:
+                                    backend.resolve(backend.setGpuPptTdp(25000, 35000, 30000), (limits: number[]) => {
+                                        set_value(TDP, limits[0]/1000);
+                                        set_value(FAST_PPT_GPU, limits[1]);
+                                        set_value(SLOW_PPT_GPU, limits[2]);
+                                    });
+                                    break;
+                                case 3:
+                                    backend.resolve(backend.setGpuPptTdp(30000, 53000, 43000), (limits: number[]) => {
+                                        set_value(TDP, limits[0]/1000);
+                                        set_value(FAST_PPT_GPU, limits[1]);
+                                        set_value(SLOW_PPT_GPU, limits[2]);
+                                    });
+                                    break;
+                                case 4:
+                                    break;
+                            }
+                            reloadGUI("PerformancePreset");
+                        }}
+                    />
+                    </Field>
+            </PanelSectionRow>
+            <PanelSectionRow>
+                {get_value(TDP) != null && get_value(PRESET_MODE_GPU) == 4 && <SliderField
                     label={tr("Watts")}
                     value={get_value(TDP)}
-                    max={(get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.max / 1000}
-                    min={(get_value(LIMITS_INFO) as backend.SettingsLimits).gpu.slow_ppt_limits!.min / 1000}
+                    max={30}
+                    min={7}
                     step={1}
                     showValue={true}
-                    disabled={get_value(TDP) == null}
+                    disabled={get_value(TDP) == null || get_value(PRESET_MODE_GPU) != 4}
                     onChange={(tdp: number) => {
                         backend.log(backend.LogLevel.Debug, "TDP is now " + tdp.toString());
                         const oldTDP = get_value(TDP);
                         const newTdp = tdp;
                         if (newTdp != oldTDP) {
-                            backend.resolve(backend.setGpuPpt(newTdp * 1000 + 2000, newTdp * 1000),
+                            backend.resolve(backend.setGpuPptTdp(newTdp * 1000, newTdp * 1000 + 2000, newTdp * 1000),
                                 (limits: number[]) => {
-                                    set_value(FAST_PPT_GPU, limits[0]);
-                                    set_value(SLOW_PPT_GPU, limits[1]);
-                                    set_value(TDP, limits[1] / 1000);
+                                    set_value(TDP, limits[0] / 1000);
+                                    set_value(FAST_PPT_GPU, limits[1]);
+                                    set_value(SLOW_PPT_GPU, limits[2]);
                                     reloadGUI("GPUTDP");
                                 });
                         }
                     }}
                 />}
             </PanelSectionRow>
-            </Fragment>);
+        </Fragment>);
     }
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -24,6 +24,7 @@ export const GOVERNOR_CPU = "CPUs_governor";
 export const FAST_PPT_GPU = "GPU_fastPPT";
 export const SLOW_PPT_GPU = "GPU_slowPPT";
 export const TDP = "GPU_TDP";
+export const PRESET_MODE_GPU = "PRESET_MODE_GPU";
 export const CLOCK_MIN_GPU = "GPU_min_clock";
 export const CLOCK_MAX_GPU = "GPU_max_clock";
 export const SLOW_MEMORY_GPU = "GPU_slow_memory";
@@ -34,6 +35,6 @@ export const PATH_GEN = "GENERAL_path";
 
 export const MESSAGE_LIST = "MESSAGE_messages";
 
-export const PERIODICAL_BACKEND_PERIOD = 5000; // milliseconds
+export const PERIODICAL_BACKEND_PERIOD = 1000; // milliseconds
 export const AUTOMATIC_REAPPLY_WAIT = 2000; // milliseconds
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,6 +64,7 @@ import {
   PERIODICAL_BACKEND_PERIOD,
   AUTOMATIC_REAPPLY_WAIT,
   TDP,
+  PRESET_MODE_GPU,
 } from "./consts";
 import { set_value, get_value } from "usdpl-front";
 import { Debug } from "./components/debug";
@@ -143,11 +144,14 @@ const reload = function() {
     set_value(GOVERNOR_CPU, governors);
     backend.log(backend.LogLevel.Info, "POWERTOOLS: Governors from backend " + governors.toString());
   });
-
-  backend.resolve(backend.getGpuPpt(), (ppts: number[]) => {
-    set_value(FAST_PPT_GPU, ppts[0]);
-    set_value(SLOW_PPT_GPU, ppts[1]);
-    set_value(TDP, ppts[1]/1000);
+  backend.resolve(backend.getPreset(), (preset: number) => {
+    backend.log(backend.LogLevel.Info, "FRONTEND: Load preset mode: " + preset.toString());
+    set_value(PRESET_MODE_GPU, preset);
+  });
+  backend.resolve(backend.getGpuPptTdp(), (ppts: number[]) => {
+    set_value(TDP, ppts[0]/1000);
+    set_value(FAST_PPT_GPU, ppts[1]);
+    set_value(SLOW_PPT_GPU, ppts[2]);
   });
   backend.resolve(backend.getGpuClockLimits(), (limits: number[]) => {
     set_value(CLOCK_MIN_GPU, limits[0]);


### PR DESCRIPTION
This PR revamps the TDP control to support 4 preset modes: 10W, 15W, 25W, 30W, and a Manual mode where we can set whatever we want.